### PR TITLE
Add command to publish routes

### DIFF
--- a/src/Console/Commands/ProjectSettingPublishRoutesCommand.php
+++ b/src/Console/Commands/ProjectSettingPublishRoutesCommand.php
@@ -77,7 +77,7 @@ class ProjectSettingPublishRoutesCommand extends Command
     private function publishConfiguration($forcePublish = false)
     {
         $params = [
-            '--provider' => 'Mabrouk\Permission\PermissionServiceProvider',
+            '--provider' => 'Mabrouk\ProjectSetting\ProjectSettingServiceProvider',
         ];
 
         if ($forcePublish === true) {

--- a/src/Console/Commands/ProjectSettingPublishRoutesCommand.php
+++ b/src/Console/Commands/ProjectSettingPublishRoutesCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Mabrouk\ProjectSetting\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class ProjectSettingPublishRoutesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'setting:publish-routes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the routes for the Project Setting package';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $routesPublishSubDirectory = config('project_settings.routes_publish_subdirectory');
+
+        $routes = [
+            'project_settings_admin_routes.php',
+            'project_settings_client_routes.php',
+            'project_settings_backend_routes.php',
+        ];
+
+        $alreadyPublished = true;
+
+        foreach ($routes as $route) {
+            if (!File::exists(base_path("routes/{$routesPublishSubDirectory}{$route}"))) {
+                $alreadyPublished = false;
+                break;
+            }
+        }
+
+        if ($alreadyPublished) {
+            $this->info("Routes have already been published in routes/{$routesPublishSubDirectory} directory.");
+            return Command::SUCCESS;
+        }
+
+
+        foreach ($routes as $route) {
+            $sourcePath = __DIR__ . "/../../routes/{$route}";
+            $destinationPath = base_path("routes/{$routesPublishSubDirectory}{$route}");
+            File::copy($sourcePath, $destinationPath);
+        }
+
+        $this->publishConfiguration();
+
+        $this->info('Routes have been published successfully.');
+
+        return Command::SUCCESS;
+    }
+
+    private function publishConfiguration($forcePublish = false)
+    {
+        $params = [
+            '--provider' => 'Mabrouk\Permission\PermissionServiceProvider',
+        ];
+
+        if ($forcePublish === true) {
+            $params['--force'] = true;
+        }
+
+        $this->call('vendor:publish', $params, new \Symfony\Component\Console\Output\NullOutput());
+    }
+}

--- a/src/Models/ProjectSetting.php
+++ b/src/Models/ProjectSetting.php
@@ -155,11 +155,11 @@ class ProjectSetting extends Model
             case $keyObject->projectSettingType->name == 'image' :
                 return $keyObject->mainImage; 
 
-            case !$keyObject->non_translatable_value :
+            case $keyObject->non_translatable_value == null :
                 $value = $keyObject->tr('key_value', $locale) ?? $keyObject->tr('key_value', config('translatable.fallback_locale'));
                 return $withoutTags ? \strip_tags($value) : $value;
 
-            case $keyObject->non_translatable_value :
+            case $keyObject->non_translatable_value != null :
                 return $asInt ? (int) $keyObject->non_translatable_value : $keyObject->non_translatable_value;
                 
             default:

--- a/src/ProjectSettingServiceProvider.php
+++ b/src/ProjectSettingServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Mabrouk\ProjectSetting\Console\Commands\ProjectSettingInstallCommand;
+use Mabrouk\ProjectSetting\Console\Commands\ProjectSettingPublishRoutesCommand;
 use Mabrouk\ProjectSetting\Console\Commands\ProjectSettingTypeUpdateCommand;
 
 class ProjectSettingServiceProvider extends ServiceProvider
@@ -53,6 +54,7 @@ class ProjectSettingServiceProvider extends ServiceProvider
             $this->commands([
                 ProjectSettingInstallCommand::class,
                 ProjectSettingTypeUpdateCommand::class,
+                ProjectSettingPublishRoutesCommand::class,
             ]);
 
             /**
@@ -83,11 +85,13 @@ class ProjectSettingServiceProvider extends ServiceProvider
 
     protected function registerRoutes()
     {
-        Route::group($this->routeConfiguration(), function () {
-            $this->loadRoutesFrom(__DIR__ . '/routes/project_settings_admin_routes.php');
-            $this->loadRoutesFrom(__DIR__ . '/routes/project_settings_client_routes.php');
-            $this->loadRoutesFrom(__DIR__ . '/routes/project_settings_backend_routes.php');
-        });
+        if (config('project_settings.load_routes')) {
+            Route::group($this->routeConfiguration(), function () {
+                $this->loadRoutesFrom(__DIR__ . '/routes/project_settings_admin_routes.php');
+                $this->loadRoutesFrom(__DIR__ . '/routes/project_settings_client_routes.php');
+                $this->loadRoutesFrom(__DIR__ . '/routes/project_settings_backend_routes.php');
+            });
+        }
     }
 
     protected function routeConfiguration()

--- a/src/config/project_settings.php
+++ b/src/config/project_settings.php
@@ -70,4 +70,27 @@ return [
     */
    'package_client_routes_prefix' => '',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Routes publish subdirectory
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the subdirectory where the package routes should be
+    | published inside the project's routes folder. This allows you to customize the location of the published
+    | routes files.
+    |
+    */
+    # eg: 'routes_publish_subdirectory' => 'custom/',
+    'routes_publish_subdirectory' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load Routes
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether the package routes should be loaded.
+    | Set this value to true to load the routes, or false to disable them.
+    |
+    */
+    'load_routes' => true,
 ];


### PR DESCRIPTION
- Changes

1. Add ProjectSettingPublishRoutesCommand to publish routes.
2. Add 'routes_publish_subdirectory' to specify routes should be published inside the project's routes folder
3. Add 'load_routes' to enable/disable route registering from service provider