### PR TITLE
modify project setting item seeding to seed non-existing items only

### DIFF
--- a/src/database/seeders/ProjectSettingSectionsWithItemsSeeder.php
+++ b/src/database/seeders/ProjectSettingSectionsWithItemsSeeder.php
@@ -30,6 +30,7 @@ class ProjectSettingSectionsWithItemsSeeder extends Seeder
 
         $allProjectSettingTypes = ProjectSettingType::all();
         $allProjectSettingGroups = ProjectSettingGroup::all();
+        $allProjectSettingItems = ProjectSetting::all();
         $fillableAttributes = (new ProjectSettingSection())->getFillable();
 
         for ($i = 0; $i < \count($projectSettingSections); $i++) {
@@ -42,7 +43,9 @@ class ProjectSettingSectionsWithItemsSeeder extends Seeder
             );
 
             self::addModelTranslation($projectSettingSection, $projectSettingSections[$i]['translation_data']);
-            self::addSectionSettings($allProjectSettingTypes, $projectSettingSection, $projectSettingSections[$i]['settings']);
+
+            $settingItemsToBeAdded = collect($projectSettingSections[$i]['settings'])->whereNotIn('key', $allProjectSettingItems->pluck('key'))->toArray();
+            self::addSectionSettings($allProjectSettingTypes, $projectSettingSection, $settingItemsToBeAdded);
         }
 
         ProjectSetting::cache(true);
@@ -56,10 +59,6 @@ class ProjectSettingSectionsWithItemsSeeder extends Seeder
             $settingType = $allProjectSettingTypes->where('name', $projectSettingData['type_name'])->first();
 
             if (!$settingType) continue;
-
-            $existingSetting = $projectSettingSection->projectSettings()->where('key', $projectSettingData['key'])->first();
-
-            if ($existingSetting) continue;
 
             $setting = $projectSettingSection->projectSettings()
                 ->create(

--- a/src/database/seeders/ProjectSettingSectionsWithItemsSeeder.php
+++ b/src/database/seeders/ProjectSettingSectionsWithItemsSeeder.php
@@ -57,6 +57,10 @@ class ProjectSettingSectionsWithItemsSeeder extends Seeder
 
             if (!$settingType) continue;
 
+            $existingSetting = $projectSettingSection->projectSettings()->where('key', $projectSettingData['key'])->first();
+
+            if ($existingSetting) continue;
+
             $setting = $projectSettingSection->projectSettings()
                 ->create(
                     \array_merge(
@@ -92,8 +96,6 @@ class ProjectSettingSectionsWithItemsSeeder extends Seeder
     {
         ProjectSettingSection::truncate();
         ProjectSettingSectionTranslation::truncate();
-        ProjectSetting::truncate();
-        ProjectSettingTranslation::truncate();
 
         return true;
     }


### PR DESCRIPTION
- Changes

1. Remove project setting items truncation from ProjectSettingSectionsWithItemsSeeder
2. Modify project setting items seeding process to create non-existing items only