### PR TITLE
Feature/deprecate some endpoints for groups and sections and items in admin

### DIFF
--- a/src/Filters/Backend/ProjectSettingGroupFilter.php
+++ b/src/Filters/Backend/ProjectSettingGroupFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mabrouk\ProjectSetting\Filters\Backend;
+
+use Mabrouk\Filterable\Helpers\QueryFilter;
+
+class ProjectSettingGroupFilter extends QueryFilter
+{
+    public function search($search = '')
+    {
+        return $search ? $this->builder->search($search) : $this->builder;
+    }
+
+    public function visible($visible = 'yes')
+    {
+        return \in_array($visible, \array_keys($this->availableBooleanValues)) ? $this->builder->visible($this->availableBooleanValues[$visible]) : $this->builder;
+    }
+}

--- a/src/Http/Controllers/Admin/ProjectSettingGroupController.php
+++ b/src/Http/Controllers/Admin/ProjectSettingGroupController.php
@@ -20,26 +20,26 @@ class ProjectSettingGroupController extends Controller
     public function index(ProjectSettingGroupFilter $filters)
     {
         $paginationLength = pagination_length(ProjectSettingGroup::class);
-        $projectSettingGroups = ProjectSettingGroup::visible()->filter($filters)->paginate($paginationLength);
+        $projectSettingGroups = ProjectSettingGroup::visible()->filter($filters)->with('translations')->paginate($paginationLength);
 
         return ProjectSettingGroupResource::collection($projectSettingGroups);
     }
 
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param ProjectSettingGroupStoreRequest $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(ProjectSettingGroupStoreRequest $request)
-    {
-        $projectSettingGroup = $request->storeProjectSettingGroup();
+    // /**
+    //  * Store a newly created resource in storage.
+    //  *
+    //  * @param ProjectSettingGroupStoreRequest $request
+    //  * @return \Illuminate\Http\Response
+    //  */
+    // public function store(ProjectSettingGroupStoreRequest $request)
+    // {
+    //     $projectSettingGroup = $request->storeProjectSettingGroup();
 
-        return response([
-            'message' => __('mabrouk/project_settings/project_setting_groups.store'),
-            'project_setting_group' => new ProjectSettingGroupResource($projectSettingGroup),
-        ]);
-    }
+    //     return response([
+    //         'message' => __('mabrouk/project_settings/project_setting_groups.store'),
+    //         'project_setting_group' => new ProjectSettingGroupResource($projectSettingGroup),
+    //     ]);
+    // }
 
     /**
      * Display the specified resource.
@@ -54,39 +54,39 @@ class ProjectSettingGroupController extends Controller
         ]);
     }
 
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param ProjectSettingGroupUpdateRequest $request
-     * @param ProjectSettingGroup $project_setting_group
-     * @return \Illuminate\Http\Response
-     */
-    public function update(ProjectSettingGroupUpdateRequest $request, ProjectSettingGroup $project_setting_group)
-    {
-        $projectSettingGroup = $request->updateProjectSettingGroup();
+    // /**
+    //  * Update the specified resource in storage.
+    //  *
+    //  * @param ProjectSettingGroupUpdateRequest $request
+    //  * @param ProjectSettingGroup $project_setting_group
+    //  * @return \Illuminate\Http\Response
+    //  */
+    // public function update(ProjectSettingGroupUpdateRequest $request, ProjectSettingGroup $project_setting_group)
+    // {
+    //     $projectSettingGroup = $request->updateProjectSettingGroup();
 
-        return response([
-            'message' => __('mabrouk/project_settings/project_setting_groups.update'),
-            'project_setting_group' => new ProjectSettingGroupResource($projectSettingGroup),
-        ]);
-    }
+    //     return response([
+    //         'message' => __('mabrouk/project_settings/project_setting_groups.update'),
+    //         'project_setting_group' => new ProjectSettingGroupResource($projectSettingGroup),
+    //     ]);
+    // }
 
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param ProjectSettingGroup $project_setting_group
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(ProjectSettingGroup $project_setting_group)
-    {
-        if (!$project_setting_group->remove()) {
-            return response([
-                'message' => __('mabrouk/project_settings/project_setting_groups.cant_destroy'),
-            ], 409);
-        }
+    // /**
+    //  * Remove the specified resource from storage.
+    //  *
+    //  * @param ProjectSettingGroup $project_setting_group
+    //  * @return \Illuminate\Http\Response
+    //  */
+    // public function destroy(ProjectSettingGroup $project_setting_group)
+    // {
+    //     if (!$project_setting_group->remove()) {
+    //         return response([
+    //             'message' => __('mabrouk/project_settings/project_setting_groups.cant_destroy'),
+    //         ], 409);
+    //     }
 
-        return response([
-            'message' => __('mabrouk/project_settings/project_setting_groups.destroy'),
-        ]);
-    }
+    //     return response([
+    //         'message' => __('mabrouk/project_settings/project_setting_groups.destroy'),
+    //     ]);
+    // }
 }

--- a/src/Http/Controllers/Admin/ProjectSettingSectionController.php
+++ b/src/Http/Controllers/Admin/ProjectSettingSectionController.php
@@ -22,27 +22,35 @@ class ProjectSettingSectionController extends Controller
     public function index(ProjectSettingGroup $project_setting_group, ProjectSettingSectionFilter $filters)
     {
         $paginationLength = pagination_length(ProjectSettingSection::class);
-        $projectSettingSections = $project_setting_group->projectSettingSections()->filter($filters)->with(['projectSettingGroup', 'projectSettings'])->paginate($paginationLength);
+        $projectSettingSections = $project_setting_group->projectSettingSections()
+            ->filter($filters)
+            ->with([
+                'projectSettingGroup.translations',
+                'projectSettings.projectSettingType',
+                'projectSettings.phone',
+                'projectSettings.media',
+                'projectSettings.translations',
+            ])->paginate($paginationLength);
 
         return ProjectSettingSectionResource::collection($projectSettingSections);
     }
 
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param ProjectSettingSectionStoreRequest $request
-     * @param ProjectSettingGroup $project_setting_group
-     * @return \Illuminate\Http\Response
-     */
-    public function store(ProjectSettingSectionStoreRequest $request, ProjectSettingGroup $project_setting_group)
-    {
-        $projectSettingSection = $request->storeProjectSettingSection();
+    // /**
+    //  * Store a newly created resource in storage.
+    //  *
+    //  * @param ProjectSettingSectionStoreRequest $request
+    //  * @param ProjectSettingGroup $project_setting_group
+    //  * @return \Illuminate\Http\Response
+    //  */
+    // public function store(ProjectSettingSectionStoreRequest $request, ProjectSettingGroup $project_setting_group)
+    // {
+    //     $projectSettingSection = $request->storeProjectSettingSection();
 
-        return response([
-            'message' => __('mabrouk/project_settings/project_setting_sections.store'),
-            'project_setting_section' => new ProjectSettingSectionResource($projectSettingSection),
-        ]);
-    }
+    //     return response([
+    //         'message' => __('mabrouk/project_settings/project_setting_sections.store'),
+    //         'project_setting_section' => new ProjectSettingSectionResource($projectSettingSection),
+    //     ]);
+    // }
 
     /**
      * Display the specified resource.
@@ -53,46 +61,53 @@ class ProjectSettingSectionController extends Controller
      */
     public function show(ProjectSettingGroup $project_setting_group, ProjectSettingSection $project_setting_section)
     {
+        $project_setting_section->load([
+            'projectSettingGroup.translations',
+            'projectSettings.projectSettingType',
+            'projectSettings.phone',
+            'projectSettings.media',
+        ]);
+
         return response([
             'project_setting_section' => new ProjectSettingSectionResource($project_setting_section),
         ]);
     }
 
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param ProjectSettingSectionUpdateRequest $request
-     * @param ProjectSettingGroup $project_setting_group
-     * @param ProjectSettingSection $project_setting_section
-     * @return \Illuminate\Http\Response
-     */
-    public function update(ProjectSettingSectionUpdateRequest $request, ProjectSettingGroup $project_setting_group, ProjectSettingSection $project_setting_section)
-    {
-        $projectSettingSection = $request->updateProjectSettingSection();
+    // /**
+    //  * Update the specified resource in storage.
+    //  *
+    //  * @param ProjectSettingSectionUpdateRequest $request
+    //  * @param ProjectSettingGroup $project_setting_group
+    //  * @param ProjectSettingSection $project_setting_section
+    //  * @return \Illuminate\Http\Response
+    //  */
+    // public function update(ProjectSettingSectionUpdateRequest $request, ProjectSettingGroup $project_setting_group, ProjectSettingSection $project_setting_section)
+    // {
+    //     $projectSettingSection = $request->updateProjectSettingSection();
 
-        return response([
-            'message' => __('mabrouk/project_settings/project_setting_sections.update'),
-            'project_setting_section' => new ProjectSettingSectionResource($projectSettingSection),
-        ]);
-    }
+    //     return response([
+    //         'message' => __('mabrouk/project_settings/project_setting_sections.update'),
+    //         'project_setting_section' => new ProjectSettingSectionResource($projectSettingSection),
+    //     ]);
+    // }
 
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param ProjectSettingGroup $project_setting_group
-     * @param ProjectSettingSection $project_setting_section
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(ProjectSettingGroup $project_setting_group, ProjectSettingSection $project_setting_section)
-    {
-        if (!$project_setting_section->remove()) {
-            return response([
-                'message' => __('mabrouk/project_settings/project_setting_sections.cant_destroy'),
-            ], 409);
-        }
+    // /**
+    //  * Remove the specified resource from storage.
+    //  *
+    //  * @param ProjectSettingGroup $project_setting_group
+    //  * @param ProjectSettingSection $project_setting_section
+    //  * @return \Illuminate\Http\Response
+    //  */
+    // public function destroy(ProjectSettingGroup $project_setting_group, ProjectSettingSection $project_setting_section)
+    // {
+    //     if (!$project_setting_section->remove()) {
+    //         return response([
+    //             'message' => __('mabrouk/project_settings/project_setting_sections.cant_destroy'),
+    //         ], 409);
+    //     }
 
-        return response([
-            'message' => __('mabrouk/project_settings/project_setting_sections.destroy'),
-        ]);
-    }
+    //     return response([
+    //         'message' => __('mabrouk/project_settings/project_setting_sections.destroy'),
+    //     ]);
+    // }
 }

--- a/src/Http/Controllers/Backend/ProjectSettingGroupController.php
+++ b/src/Http/Controllers/Backend/ProjectSettingGroupController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mabrouk\ProjectSetting\Http\Controllers\Admin;
+namespace Mabrouk\ProjectSetting\Http\Controllers\Backend;
 
 use Mabrouk\ProjectSetting\Filters\Backend\ProjectSettingGroupFilter;
 use Mabrouk\ProjectSetting\Http\Controllers\Controller;

--- a/src/Http/Controllers/Backend/ProjectSettingGroupController.php
+++ b/src/Http/Controllers/Backend/ProjectSettingGroupController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Mabrouk\ProjectSetting\Http\Controllers\Admin;
+
+use Mabrouk\ProjectSetting\Filters\Backend\ProjectSettingGroupFilter;
+use Mabrouk\ProjectSetting\Http\Controllers\Controller;
+use Mabrouk\ProjectSetting\Http\Requests\Backend\ProjectSettingGroupStoreRequest;
+use Mabrouk\ProjectSetting\Http\Requests\Backend\ProjectSettingGroupUpdateRequest;
+use Mabrouk\ProjectSetting\Http\Resources\Backend\ProjectSettingGroupResource;
+use Mabrouk\ProjectSetting\Models\ProjectSettingGroup;
+
+class ProjectSettingGroupController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param ProjectSettingGroupFilter $filters
+     * @return \Illuminate\Http\Response
+     */
+    public function index(ProjectSettingGroupFilter $filters)
+    {
+        $paginationLength = pagination_length(ProjectSettingGroup::class);
+        $projectSettingGroups = ProjectSettingGroup::filter($filters)->with('translations')->paginate($paginationLength);
+
+        return ProjectSettingGroupResource::collection($projectSettingGroups);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param ProjectSettingGroupStoreRequest $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(ProjectSettingGroupStoreRequest $request)
+    {
+        $projectSettingGroup = $request->storeProjectSettingGroup();
+
+        return response([
+            'message' => __('mabrouk/project_settings/project_setting_groups.store'),
+            'project_setting_group' => new ProjectSettingGroupResource($projectSettingGroup),
+        ]);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param ProjectSettingGroup $project_setting_group
+     * @return \Illuminate\Http\Response
+     */
+    public function show(ProjectSettingGroup $project_setting_group)
+    {
+        return response([
+            'project_setting_group' => new ProjectSettingGroupResource($project_setting_group),
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param ProjectSettingGroupUpdateRequest $request
+     * @param ProjectSettingGroup $project_setting_group
+     * @return \Illuminate\Http\Response
+     */
+    public function update(ProjectSettingGroupUpdateRequest $request, ProjectSettingGroup $project_setting_group)
+    {
+        $projectSettingGroup = $request->updateProjectSettingGroup();
+
+        return response([
+            'message' => __('mabrouk/project_settings/project_setting_groups.update'),
+            'project_setting_group' => new ProjectSettingGroupResource($projectSettingGroup),
+        ]);
+    }
+}

--- a/src/Http/Controllers/Client/ProjectSettingController.php
+++ b/src/Http/Controllers/Client/ProjectSettingController.php
@@ -18,7 +18,7 @@ class ProjectSettingController extends Controller
     public function index(ProjectSettingFilter $filters)
     {
         $paginationLength = pagination_length(ProjectSetting::class);
-        $projectSettings = ProjectSetting::returnToClient()->visible()->filter($filters)->with(['projectSettingType', 'phone', 'media'])->paginate($paginationLength);
+        $projectSettings = ProjectSetting::returnToClient()->visible()->filter($filters)->with(['projectSettingType', 'phone', 'media', 'translations'])->paginate($paginationLength);
 
         return ProjectSettingResource::collection($projectSettings);
     }

--- a/src/Http/Requests/Admin/ProjectSettingUpdateRequest.php
+++ b/src/Http/Requests/Admin/ProjectSettingUpdateRequest.php
@@ -27,10 +27,10 @@ class ProjectSettingUpdateRequest extends FormRequest
     public function rules()
     {
         return \array_merge([
-            'section' => 'sometimes|integer|exists:project_setting_sections,id',
+            // 'section' => 'sometimes|integer|exists:project_setting_sections,id',
 
-            'name' => 'sometimes|string|min:2|max:191',
-            'description' => 'sometimes|string|min:2|max:191',
+            // 'name' => 'sometimes|string|min:2|max:191',
+            // 'description' => 'sometimes|string|min:2|max:191',
 
             'displayed' => [
                 'sometimes', 
@@ -60,7 +60,7 @@ class ProjectSettingUpdateRequest extends FormRequest
     {
         DB::transaction(function () {
             $this->project_setting->update([
-                'project_setting_section_id' => $this->exists('section') ? $this->section : $this->project_setting->project_setting_section_id,
+                // 'project_setting_section_id' => $this->exists('section') ? $this->section : $this->project_setting->project_setting_section_id,
                 'non_translatable_value' => $this->exists('value') && (! $this->project_setting->isTranslatable) ? $this->value : $this->project_setting->non_translatable_value,
 
                 'is_displayed' => $this->exists('displayed') ? $this->displayed : $this->project_setting->is_displayed,

--- a/src/Http/Requests/Backend/ProjectSettingGroupStoreRequest.php
+++ b/src/Http/Requests/Backend/ProjectSettingGroupStoreRequest.php
@@ -8,8 +8,6 @@ use Mabrouk\ProjectSetting\Models\ProjectSettingGroup;
 
 class ProjectSettingGroupStoreRequest extends FormRequest
 {
-    public ProjectSettingGroup $projectSettingGroup;
-
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -37,12 +35,13 @@ class ProjectSettingGroupStoreRequest extends FormRequest
 
     public function storeProjectSettingGroup()
     {
-        DB::transaction(function () {
-            $this->projectSettingGroup = ProjectSettingGroup::create([
+        return DB::transaction(function () {
+            $projectSettingGroup = ProjectSettingGroup::create([
                 'slug' => $this->slug,
             ]);
+
+            return $projectSettingGroup->refresh();
         });
-        return $this->projectSettingGroup->refresh();
     }
 
     public function attributes(): array

--- a/src/Http/Requests/Backend/ProjectSettingGroupStoreRequest.php
+++ b/src/Http/Requests/Backend/ProjectSettingGroupStoreRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Mabrouk\ProjectSetting\Http\Requests\Backend;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Foundation\Http\FormRequest;
+use Mabrouk\ProjectSetting\Models\ProjectSettingGroup;
+
+class ProjectSettingGroupStoreRequest extends FormRequest
+{
+    public ProjectSettingGroup $projectSettingGroup;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'slug' => 'required|string|min:2|max:191|unique:project_setting_groups,slug',
+
+            'name' => 'required|string|min:2|max:191',
+            'description' => 'required|string|min:2|max:191',
+        ];
+    }
+
+    public function storeProjectSettingGroup()
+    {
+        DB::transaction(function () {
+            $this->projectSettingGroup = ProjectSettingGroup::create([
+                'slug' => $this->slug,
+            ]);
+        });
+        return $this->projectSettingGroup->refresh();
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'slug' => __('mabrouk/project_settings/project_setting_groups.attributes.slug'),
+            'name' => __('mabrouk/project_settings/project_setting_groups.attributes.name'),
+            'description' => __('mabrouk/project_settings/project_setting_groups.attributes.description'),
+        ];
+    }
+}

--- a/src/Http/Requests/Backend/ProjectSettingGroupUpdateRequest.php
+++ b/src/Http/Requests/Backend/ProjectSettingGroupUpdateRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Mabrouk\ProjectSetting\Http\Requests\Backend;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProjectSettingGroupUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'slug' => 'sometimes|string|min:2|max:191|unique:project_setting_groups,slug,' . $this->project_setting_group->id,
+
+            'name' => 'sometimes|string|min:2|max:191',
+            'description' => 'sometimes|string|min:2|max:191',
+        ];
+    }
+
+    public function getValidatorInstance()
+    {
+        request()->locale = request()->input('locale');
+        return parent::getValidatorInstance();
+    }
+
+    public function updateProjectSettingGroup()
+    {
+        DB::transaction(function () {
+            $this->project_setting_group->update([
+                'slug' => $this->exists('slug') ? $this->slug : $this->project_setting_group->slug,
+            ]);
+        });
+        return $this->project_setting_group->refresh();
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'slug' => __('mabrouk/project_settings/project_setting_groups.attributes.slug'),
+            'name' => __('mabrouk/project_settings/project_setting_groups.attributes.name'),
+            'description' => __('mabrouk/project_settings/project_setting_groups.attributes.description'),
+        ];
+    }
+}

--- a/src/Http/Resources/Backend/ProjectSettingGroupResource.php
+++ b/src/Http/Resources/Backend/ProjectSettingGroupResource.php
@@ -4,7 +4,7 @@ namespace Mabrouk\ProjectSetting\Http\Resources\Backend;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class ProjectSettingGroupSimpleResource extends JsonResource
+class ProjectSettingGroupResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
@@ -22,6 +22,8 @@ class ProjectSettingGroupSimpleResource extends JsonResource
             'description' => $this->description,
 
             'visible' => $this->is_visible,
+
+            // 'sections' => ProjectSettingSectionResource::collection($this->projectSettingSections),
         ];
     }
 }

--- a/src/Http/Resources/Backend/ProjectSettingSectionResource.php
+++ b/src/Http/Resources/Backend/ProjectSettingSectionResource.php
@@ -21,7 +21,7 @@ class ProjectSettingSectionResource extends JsonResource
             'name' => $this->name,
             'description' => $this->description,
 
-            'project_setting_group' => new ProjectSettingGroupSimpleResource($this->projectSettingGroup),
+            'project_setting_group' => new ProjectSettingGroupResource($this->projectSettingGroup),
             'project_settings' => ProjectSettingSimpleResource::collection($this->projectSettings),
         ];
     }

--- a/src/Http/Resources/Backend/ProjectSettingSectionSimpleResource.php
+++ b/src/Http/Resources/Backend/ProjectSettingSectionSimpleResource.php
@@ -21,7 +21,7 @@ class ProjectSettingSectionSimpleResource extends JsonResource
             'name' => $this->name,
             'description' => $this->description,
 
-            'project_setting_group' => new ProjectSettingGroupSimpleResource($this->projectSettingGroup),
+            'project_setting_group' => new ProjectSettingGroupResource($this->projectSettingGroup),
         ];
     }
 }

--- a/src/routes/project_settings_admin_routes.php
+++ b/src/routes/project_settings_admin_routes.php
@@ -16,7 +16,7 @@ Route::group([
     ]
 ], function () {
     Route::apiResource('project-setting-types', ProjectSettingTypeController::class)->only(['index', 'show']);
-    Route::apiResource('project-setting-groups', ProjectSettingGroupController::class);
-    Route::apiResource('project-setting-groups.project-setting-sections', ProjectSettingSectionController::class)->scoped();
+    Route::apiResource('project-setting-groups', ProjectSettingGroupController::class)->only(['index', 'show']);
+    Route::apiResource('project-setting-groups.project-setting-sections', ProjectSettingSectionController::class)->only(['index', 'show'])->scoped();
     Route::apiResource('project-setting-groups.project-setting-sections.project-settings', ProjectSettingController::class)->except(['store', 'destroy'])->scoped();
 });

--- a/src/routes/project_settings_backend_routes.php
+++ b/src/routes/project_settings_backend_routes.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Mabrouk\ProjectSetting\Http\Controllers\Backend\ProjectSettingGroupController;
 use Mabrouk\ProjectSetting\Http\Controllers\Backend\ProjectSettingController;
 use Mabrouk\ProjectSetting\Http\Controllers\Backend\ProjectSettingSectionController;
 
@@ -13,6 +14,7 @@ Route::group([
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
     ]
 ], function () {
+    Route::apiResource('project-setting-groups', ProjectSettingGroupController::class)->except(['destroy']);
     Route::apiResource('project-settings', ProjectSettingController::class)->except(['show', 'destroy']);
     Route::apiResource('project-setting-groups.project-setting-sections', ProjectSettingSectionController::class)->scoped();
 });


### PR DESCRIPTION
- deprecate store, update and destroy for groups in admin side
- deprecate store, update and destroy for sections in admin side
- make full crud except destroy for groups in backend side
- comment fields (section, name, description) in ProjectSettingUpdateRequest in admin side
- handle eager loading in some endpoints